### PR TITLE
Uri support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Add URI support as `asUri` method
+
 ## 2.0.1+1
 
 * Small README change

--- a/lib/whatsapp_unilink.dart
+++ b/lib/whatsapp_unilink.dart
@@ -38,6 +38,9 @@ class WhatsAppUnilink {
     return sb.toString();
   }
 
+  /// Represent this as a Uri component.
+  Uri asUri() => Uri.parse('$this');
+
   /// Keep only the numbers and remove any leading zeros
   static String _formatPhoneNumber(String phoneNumber) {
     return phoneNumber

--- a/lib/whatsapp_unilink.dart
+++ b/lib/whatsapp_unilink.dart
@@ -39,7 +39,15 @@ class WhatsAppUnilink {
   }
 
   /// Represent this as a Uri component.
-  Uri asUri() => Uri.parse('$this');
+  Uri asUri() {
+    final text = this.text;
+    return Uri(
+      scheme: 'https',
+      host: 'wa.me',
+      path: phoneNumber?.use(_formatPhoneNumber),
+      queryParameters: text == null ? null : {'text': text},
+    );
+  }
 
   /// Keep only the numbers and remove any leading zeros
   static String _formatPhoneNumber(String phoneNumber) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: whatsapp_unilink
 description: Dart package helping your app interact with WhatsApp via HTTP links (universal links). Works with Flutter.
 homepage: https://github.com/dartsidedev/whatsapp_unilink
 issue_tracker: https://github.com/dartsidedev/whatsapp_unilink/issues
-version: 2.0.1+1
+version: 2.1.0
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:

--- a/test/whatsapp_unilink_test.dart
+++ b/test/whatsapp_unilink_test.dart
@@ -60,5 +60,62 @@ void main() {
         );
       });
     });
+    group('asUri', () {
+      test('phone number and text are both set', () {
+        expect(
+          WhatsAppUnilink(
+            phoneNumber: '+001-(555)1234567',
+            text: 'I\'m interested in in your "Ferrari" car for sale!',
+          ).asUri(),
+          Uri.parse(
+            'https://wa.me/15551234567?text=I\'m%20interested%20in%20in%20your%20%22Ferrari%22%20car%20for%20sale!',
+          ),
+        );
+      });
+
+      test('only phone number is set: +, -, (, )', () {
+        expect(
+          WhatsAppUnilink(phoneNumber: '+001-(555)1230067').asUri(),
+          Uri.parse('https://wa.me/15551230067'),
+        );
+      });
+
+      test('only phone number is set: +, -, (, ) and spaces', () {
+        expect(
+          WhatsAppUnilink(phoneNumber: '+001 - (555) 1230067').asUri(),
+          Uri.parse('https://wa.me/15551230067'),
+        );
+      });
+
+      test('only phone number is set: already formatted', () {
+        expect(
+          WhatsAppUnilink(phoneNumber: '4911122233456').asUri(),
+          Uri.parse('https://wa.me/4911122233456'),
+        );
+      });
+
+      test('only phone number is set: starts with +', () {
+        expect(
+          WhatsAppUnilink(phoneNumber: '+4911122233456').asUri(),
+          Uri.parse('https://wa.me/4911122233456'),
+        );
+      });
+
+      test('only phone number is set: leading zero', () {
+        expect(
+          WhatsAppUnilink(phoneNumber: '004911122233456').asUri(),
+          Uri.parse('https://wa.me/4911122233456'),
+        );
+      });
+
+      test('only the text is set', () {
+        expect(
+          WhatsAppUnilink(text: 'I\'m interested in ur "Ferrari"!').asUri(),
+          Uri.parse(
+            'https://wa.me/?text=I\'m%20interested%20in%20ur%20%22Ferrari%22!',
+          ),
+        );
+      });
+    });
   });
 }

--- a/test/whatsapp_unilink_test.dart
+++ b/test/whatsapp_unilink_test.dart
@@ -68,7 +68,7 @@ void main() {
             text: 'I\'m interested in in your "Ferrari" car for sale!',
           ).asUri(),
           Uri.parse(
-            'https://wa.me/15551234567?text=I\'m%20interested%20in%20in%20your%20%22Ferrari%22%20car%20for%20sale!',
+            'https://wa.me/15551234567?text=I%27m+interested+in+in+your+%22Ferrari%22+car+for+sale%21',
           ),
         );
       });
@@ -112,7 +112,7 @@ void main() {
         expect(
           WhatsAppUnilink(text: 'I\'m interested in ur "Ferrari"!').asUri(),
           Uri.parse(
-            'https://wa.me/?text=I\'m%20interested%20in%20ur%20%22Ferrari%22!',
+            'https://wa.me?text=I%27m+interested+in+ur+%22Ferrari%22%21',
           ),
         );
       });


### PR DESCRIPTION
Developers working with `Uri` components must always type `Uri.parse(WhatsAppUnilink(...).toString())` in order to manipulate or extract data from it. A main example is the new [`launchUrl`](https://pub.dev/documentation/url_launcher/latest/url_launcher/launchUrl.html) function from [url_launcher](https://pub.dev/packages/url_launcher). 

This PR tries to simplify this pattern by adding a **`asUri` method** into the `WhatsAppUnilink` class. This new method creates the `Uri` *directly* from its constructor instead of parsing it from `toString` and adding more overhead.

With this PR, after adding the tests, two comparisons needed to be changed because of [the way the space character is encoded](https://stackoverflow.com/q/1634271/9997212):

```none
test\whatsapp_unilink_test.dart: WhatsAppUnilink asUri phone number and text are both set
then: https://wa.me/15551234567?text=I'm%20interested%20in%20in%20your%20%22Ferrari%22%20car%20for%20sale!
 now: https://wa.me/15551234567?text=I%27m+interested+in+in+your+%22Ferrari%22+car+for+sale%21

test\whatsapp_unilink_test.dart: WhatsAppUnilink asUri only the text is set 
then: https://wa.me/?text=I'm%20interested%20in%20ur%20%22Ferrari%22!
 now: https://wa.me?text=I%27m+interested+in+ur+%22Ferrari%22%21
```